### PR TITLE
Remove creation date if present

### DIFF
--- a/dorecur.py
+++ b/dorecur.py
@@ -178,6 +178,10 @@ def make_new_task(line, now=datetime.date.today()):
     'Test task rec:3d'
     >>> make_new_task('(A) 1970-01-01 Test task rec:3d', now)
     '(A) Test task rec:3d'
+    >>> make_new_task('(A) 1970 Test task rec:3d', now)
+    '(A) 1970 Test task rec:3d'
+    >>> make_new_task('(A) Test task with 1970-01-01 in it rec:3d', now)
+    '(A) Test task with 1970-01-01 in it rec:3d'
     >>> make_new_task('Test task rec:+3d', now)
     'Test task rec:+3d'
     >>> make_new_task('Test task t:1970-01-01 rec:3d', now)

--- a/dorecur.py
+++ b/dorecur.py
@@ -176,6 +176,8 @@ def make_new_task(line, now=datetime.date.today()):
     'Test task rec:3d'
     >>> make_new_task('1970-01-01 Test task rec:3d', now)
     'Test task rec:3d'
+    >>> make_new_task('(A) 1970-01-01 Test task rec:3d', now)
+    '(A) Test task rec:3d'
     >>> make_new_task('Test task rec:+3d', now)
     'Test task rec:+3d'
     >>> make_new_task('Test task t:1970-01-01 rec:3d', now)

--- a/dorecur.py
+++ b/dorecur.py
@@ -236,6 +236,10 @@ def make_new_task(line, now=datetime.date.today()):
         return None
     start_date = get_date(line, 't')
     due_date = get_date(line, 'due')
+
+    # Remove optional creation date
+    line = re.sub("^(?P<pri>\([A-Z]\) )?\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]) ", "\g<pri>", line)
+
     if not start_date and not due_date:
         # Neither date is specified
         return line

--- a/dorecur.py
+++ b/dorecur.py
@@ -174,6 +174,8 @@ def make_new_task(line, now=datetime.date.today()):
     >>> make_new_task('Test task', now)
     >>> make_new_task('Test task rec:3d', now)
     'Test task rec:3d'
+    >>> make_new_task('1970-01-01 Test task rec:3d', now)
+    'Test task rec:3d'
     >>> make_new_task('Test task rec:+3d', now)
     'Test task rec:+3d'
     >>> make_new_task('Test task t:1970-01-01 rec:3d', now)


### PR DESCRIPTION
This PR is an attempt to fix #1 by removing the task's optional creation date if present, while making sure to preserve any optional task priority.

Please review and merge, or let me know how to improve it.

In particular, I'm not sure if that's the preferred way to follow, but at least it works in my local tests. So feedback welcome about tests, commits, code, etc. :)